### PR TITLE
feat(serializers): avoid implicit sanitization

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -30,6 +30,7 @@
   * [pino.stdTimeFunctions](#pino-stdtimefunctions)
   * [pino.symbols](#pino-symbols)
   * [pino.version](#pino-version)
+  * [pino.futures](#pino-version)
 * [Interfaces](#interfaces)
   * [MultiStreamRes](#multistreamres)
   * [StreamEntry](#streamentry)
@@ -629,6 +630,19 @@ const parent = require('pino')({ onChild: (instance) => {
 }})
 // `onChild` will now be executed with the new child.
 parent.child(bindings)
+```
+
+<a id=opt-future></a>
+#### `future` (Object)
+
+The `future` object contains _opt-in_ flags specific to a Pino major version. These flags are used to change behavior,
+anticipating breaking-changes that will be introduced in the next major version.
+```js
+const parent = require('pino')({
+  future: {
+    skipUnconditionalStdSerializers: true
+  }
+})
 ```
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -532,12 +532,26 @@ Default: `'msg'`
 
 The string key for the 'message' in the JSON object.
 
-<a id=opt-messagekey></a>
+<a id=opt-errorkey></a>
 #### `errorKey` (String)
 
 Default: `'err'`
 
 The string key for the 'error' in the JSON object.
+
+<a id=opt-requestkey></a>
+#### `requestKey` (String)
+
+Default: `'req'`
+
+The string key for the 'Request' in the JSON object.
+
+<a id=opt-responsekey></a>
+#### `responseKey` (String)
+
+Default: `'res'`
+
+The string key for the 'Response' in the JSON object.
 
 <a id=opt-nestedkey></a>
 #### `nestedKey` (String)

--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -1,8 +1,21 @@
 'use strict'
 
-const warning = require('process-warning')()
-module.exports = warning
+const warning = require('process-warning')
 
-// const warnName = 'PinoWarning'
+/**
+ * Future flags, specific to the current major-version of Pino. These flags allow for breaking-changes to be introduced
+ * on a opt-in basis, anticipating behavior of the next major-version. All future flag must be frozen as false. These
+ * future flags are specific to Pino major-version 9.
+ */
+const future = Object.freeze({
+  skipUnconditionalStdSerializers: false // see PINODEP010
+})
 
-// warning.create(warnName, 'PINODEP010', 'A new deprecation')
+const PINODEP010 = warning.createDeprecation({ code: 'PINODEP010', message: 'Unconditional execution of standard serializers for HTTP Request and Response will be discontinued in the next major version.' })
+
+module.exports = {
+  warning: {
+    PINODEP010
+  },
+  future
+}

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -30,7 +30,8 @@ const {
   formatOptsSym,
   stringifiersSym,
   msgPrefixSym,
-  hooksSym
+  hooksSym,
+  futureSym
 } = require('./symbols')
 const {
   getLevel,
@@ -90,6 +91,12 @@ function child (bindings, options) {
   const serializers = this[serializersSym]
   const formatters = this[formattersSym]
   const instance = Object.create(this)
+
+  if (options.hasOwnProperty('future') === true) {
+    throw RangeError('`future` can only be set when creating a Pino instance, and this property cannot be overridden')
+  }
+
+  instance[futureSym] = this[futureSym] // assigning future from parent is safe, as future it is immutable
 
   if (options.hasOwnProperty('serializers') === true) {
     instance[serializersSym] = Object.create(null)

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -3,7 +3,6 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { EventEmitter } = require('node:events')
-const { IncomingMessage, ServerResponse } = require('node:http')
 const {
   lsCacheSym,
   levelValSym,
@@ -200,9 +199,9 @@ function write (_obj, msg, num) {
     if (msg === undefined) {
       msg = _obj.message
     }
-  } else if (_obj instanceof IncomingMessage) {
+  } else if (_obj.method && _obj.headers && _obj.socket) {
     obj = { [requestKey]: _obj }
-  } else if (_obj instanceof ServerResponse) {
+  } else if (typeof _obj.setHeader === 'function') {
     obj = { [responseKey]: _obj }
   } else {
     obj = _obj

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -3,7 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { EventEmitter } = require('node:events')
-const { IncomingMessage,  ServerResponse} = require('node:http')
+const { IncomingMessage, ServerResponse } = require('node:http')
 const {
   lsCacheSym,
   levelValSym,

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -196,6 +196,7 @@ function write (_obj, msg, num) {
   const responseKey = this[responseKeySym]
   const messageKey = this[messageKeySym]
   const mixinMergeStrategy = this[mixinMergeStrategySym] || defaultMixinMergeStrategy
+  const future = this[futureSym]
   let obj
   const streamWriteHook = this[hooksSym].streamWrite
 
@@ -207,9 +208,13 @@ function write (_obj, msg, num) {
       msg = _obj.message
     }
   } else if (_obj.method && _obj.headers && _obj.socket) {
-    obj = { [requestKey]: _obj }
+    if (future.skipUnconditionalStdSerializers) {
+      obj = { [requestKey]: _obj }
+    }
   } else if (typeof _obj.setHeader === 'function') {
-    obj = { [responseKey]: _obj }
+    if (future.skipUnconditionalStdSerializers) {
+      obj = { [responseKey]: _obj }
+    }
   } else {
     obj = _obj
     if (msg === undefined && _obj[messageKey] === undefined && _obj[errorKey]) {

--- a/lib/proto.js
+++ b/lib/proto.js
@@ -3,6 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const { EventEmitter } = require('node:events')
+const { IncomingMessage,  ServerResponse} = require('node:http')
 const {
   lsCacheSym,
   levelValSym,
@@ -20,6 +21,8 @@ const {
   serializersSym,
   formattersSym,
   errorKeySym,
+  requestKeySym,
+  responseKeySym,
   messageKeySym,
   useOnlyCustomLevelsSym,
   needsMetadataGsym,
@@ -183,6 +186,8 @@ function write (_obj, msg, num) {
   const t = this[timeSym]()
   const mixin = this[mixinSym]
   const errorKey = this[errorKeySym]
+  const requestKey = this[requestKeySym]
+  const responseKey = this[responseKeySym]
   const messageKey = this[messageKeySym]
   const mixinMergeStrategy = this[mixinMergeStrategySym] || defaultMixinMergeStrategy
   let obj
@@ -195,6 +200,10 @@ function write (_obj, msg, num) {
     if (msg === undefined) {
       msg = _obj.message
     }
+  } else if (_obj instanceof IncomingMessage) {
+    obj = { [requestKey]: _obj }
+  } else if (_obj instanceof ServerResponse) {
+    obj = { [responseKey]: _obj }
   } else {
     obj = _obj
     if (msg === undefined && _obj[messageKey] === undefined && _obj[errorKey]) {

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -31,6 +31,7 @@ const mixinMergeStrategySym = Symbol('pino.mixinMergeStrategy')
 const msgPrefixSym = Symbol('pino.msgPrefix')
 const responseKeySym = Symbol('pino.responseKey')
 const requestKeySym = Symbol('pino.requestKey')
+const futureSym = Symbol('pino.future')
 
 const wildcardFirstSym = Symbol('pino.wildcardFirst')
 
@@ -74,5 +75,6 @@ module.exports = {
   hooksSym,
   nestedKeyStrSym,
   mixinMergeStrategySym,
-  msgPrefixSym
+  msgPrefixSym,
+  futureSym
 }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -25,12 +25,12 @@ const endSym = Symbol('pino.end')
 const formatOptsSym = Symbol('pino.formatOpts')
 const messageKeySym = Symbol('pino.messageKey')
 const errorKeySym = Symbol('pino.errorKey')
+const requestKeySym = Symbol('pino.requestKey')
+const responseKeySym = Symbol('pino.responseKey')
 const nestedKeySym = Symbol('pino.nestedKey')
 const nestedKeyStrSym = Symbol('pino.nestedKeyStr')
 const mixinMergeStrategySym = Symbol('pino.mixinMergeStrategy')
 const msgPrefixSym = Symbol('pino.msgPrefix')
-const responseKeySym = Symbol('pino.responseKey')
-const requestKeySym = Symbol('pino.requestKey')
 const futureSym = Symbol('pino.future')
 
 const wildcardFirstSym = Symbol('pino.wildcardFirst')
@@ -65,8 +65,8 @@ module.exports = {
   formatOptsSym,
   messageKeySym,
   errorKeySym,
-  responseKeySym,
   requestKeySym,
+  responseKeySym,
   nestedKeySym,
   wildcardFirstSym,
   needsMetadataGsym,

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -29,6 +29,8 @@ const nestedKeySym = Symbol('pino.nestedKey')
 const nestedKeyStrSym = Symbol('pino.nestedKeyStr')
 const mixinMergeStrategySym = Symbol('pino.mixinMergeStrategy')
 const msgPrefixSym = Symbol('pino.msgPrefix')
+const responseKeySym = Symbol('pino.responseKey')
+const requestKeySym = Symbol('pino.requestKey')
 
 const wildcardFirstSym = Symbol('pino.wildcardFirst')
 
@@ -70,5 +72,7 @@ module.exports = {
   hooksSym,
   nestedKeyStrSym,
   mixinMergeStrategySym,
-  msgPrefixSym
+  msgPrefixSym,
+  responseKeySym,
+  requestKeySym,
 }

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -64,6 +64,8 @@ module.exports = {
   formatOptsSym,
   messageKeySym,
   errorKeySym,
+  responseKeySym,
+  requestKeySym,
   nestedKeySym,
   wildcardFirstSym,
   needsMetadataGsym,
@@ -72,7 +74,5 @@ module.exports = {
   hooksSym,
   nestedKeyStrSym,
   mixinMergeStrategySym,
-  msgPrefixSym,
-  responseKeySym,
-  requestKeySym,
+  msgPrefixSym
 }

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -3,6 +3,7 @@
 /* eslint no-prototype-builtins: 0 */
 
 const format = require('quick-format-unescaped')
+const { mapHttpRequest, mapHttpResponse } = require('pino-std-serializers')
 const SonicBoom = require('sonic-boom')
 const onExit = require('on-exit-leak-free')
 const {
@@ -23,10 +24,12 @@ const {
   requestKeySym,
   responseKeySym,
   nestedKeyStrSym,
-  msgPrefixSym
+  msgPrefixSym,
+  futureSym
 } = require('./symbols')
 const { isMainThread } = require('worker_threads')
 const transport = require('./transport')
+const { warning } = require('./deprecations')
 
 function noop () {
 }
@@ -41,6 +44,16 @@ function genLog (level, hook) {
   function LOG (o, ...n) {
     if (typeof o === 'object') {
       let msg = o
+      if (!this[futureSym].skipUnconditionalStdSerializers) {
+        warning.PINODEP010()
+        if (o !== null) {
+          if (o.method && o.headers && o.socket) {
+            o = mapHttpRequest(o)
+          } else if (typeof o.setHeader === 'function') {
+            o = mapHttpResponse(o)
+          }
+        }
+      }
       let formatParams
       if (msg === null && n.length === 0) {
         formatParams = [null]
@@ -128,9 +141,9 @@ function asJson (obj, msg, num, time) {
         value = serializers[key](value)
       } else if (key === errorKey && serializers.err) {
         value = serializers.err(value)
-      } else if (key === requestKey && serializers.req) {
+      } else if (key === requestKey && serializers.req && this[futureSym].skipUnconditionalStdSerializers) {
         value = serializers.req(value)
-      } else if (key === responseKey && serializers.res) {
+      } else if (key === responseKey && serializers.res && this[futureSym].skipUnconditionalStdSerializers) {
         value = serializers.res(value)
       }
 
@@ -316,7 +329,7 @@ function createArgsNormalizer (defaultOptions) {
       stream = transport({ caller, ...opts.transport, levels: customLevels })
     }
     opts = Object.assign({}, defaultOptions, opts)
-    opts.serializers = Object.assign({}, defaultOptions.serializers, opts.serializers)
+
     opts.formatters = Object.assign({}, defaultOptions.formatters, opts.formatters)
 
     if (opts.prettyPrint) {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -21,6 +21,8 @@ const {
   formattersSym,
   messageKeySym,
   errorKeySym,
+  requestKeySym,
+  responseKeySym,
   nestedKeyStrSym,
   msgPrefixSym
 } = require('./symbols')
@@ -40,13 +42,6 @@ function genLog (level, hook) {
   function LOG (o, ...n) {
     if (typeof o === 'object') {
       let msg = o
-      if (o !== null) {
-        if (o.method && o.headers && o.socket) {
-          o = mapHttpRequest(o)
-        } else if (typeof o.setHeader === 'function') {
-          o = mapHttpResponse(o)
-        }
-      }
       let formatParams
       if (msg === null && n.length === 0) {
         formatParams = [null]
@@ -113,6 +108,8 @@ function asJson (obj, msg, num, time) {
   const formatters = this[formattersSym]
   const messageKey = this[messageKeySym]
   const errorKey = this[errorKeySym]
+  const responseKey = this[responseKeySym]
+  const requestKey = this[requestKeySym]
   let data = this[lsCacheSym][num] + time
 
   // we need the child bindings added to the output first so instance logged
@@ -132,6 +129,10 @@ function asJson (obj, msg, num, time) {
         value = serializers[key](value)
       } else if (key === errorKey && serializers.err) {
         value = serializers.err(value)
+      } else if (key === requestKey && serializers.req) {
+        value = serializers.req(value)
+      } else if (key === responseKey && serializers.res) {
+        value = serializers.res(value)
       }
 
       const stringifier = stringifiers[key] || wildcardStringifier

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -3,7 +3,6 @@
 /* eslint no-prototype-builtins: 0 */
 
 const format = require('quick-format-unescaped')
-const { mapHttpRequest, mapHttpResponse } = require('pino-std-serializers')
 const SonicBoom = require('sonic-boom')
 const onExit = require('on-exit-leak-free')
 const {

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -31,7 +31,7 @@ type TimeFn = () => string;
 type MixinFn<CustomLevels extends string = never> = (mergeObject: object, level: number, logger:pino.Logger<CustomLevels>) => object;
 type MixinMergeStrategyFn = (mergeObject: object, mixinObject: object) => object;
 
-type CustomLevelLogger<CustomLevels extends string, UseOnlyCustomLevels extends boolean = boolean> = { 
+type CustomLevelLogger<CustomLevels extends string, UseOnlyCustomLevels extends boolean = boolean> = {
     /**
      * Define additional logging levels.
      */
@@ -326,6 +326,9 @@ declare namespace pino {
         (obj: unknown, msg?: string, ...args: any[]): void;
         (msg: string, ...args: any[]): void;
     }
+
+    /** Future flags for Pino major-version 9. */
+    type FutureFlags = 'skipUnconditionalStdSerializers'
 
     interface LoggerOptions<CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean> {
         transport?: TransportSingleOptions | TransportMultiOptions | TransportPipelineOptions
@@ -676,6 +679,18 @@ declare namespace pino {
          * logs newline delimited JSON with `\r\n` instead of `\n`. Default: `false`.
          */
         crlf?: boolean;
+
+        /**
+         * The `future` object contains _opt-in_ flags specific to a Pino major version. These flags are used to change behavior,
+         * anticipating breaking-changes that will be introduced in the next major version.
+         * @example
+         * const parent = require('pino')({
+         *   future: {
+         *     skipUnconditionalStdSerializers: true
+         *   }
+         * })
+         */
+        future?: Partial<Record<FutureFlags, boolean>>
     }
 
     interface ChildLoggerOptions<CustomLevels extends string = never> {
@@ -771,6 +786,7 @@ declare namespace pino {
         readonly useOnlyCustomLevelsSym: unique symbol;
         readonly formattersSym: unique symbol;
         readonly hooksSym: unique symbol;
+        readonly futureSym: unique symbol;
     };
 
     /**

--- a/pino.d.ts
+++ b/pino.d.ts
@@ -417,6 +417,14 @@ declare namespace pino {
          */
         errorKey?: string;
         /**
+         * The string key for the 'Request' in the JSON object. Default: "req".
+         */
+        requestKey?: string;
+        /**
+         * The string key for the 'Response' in the JSON object. Default: "res".
+         */
+        responseKey?: string;
+        /**
          * The string key to place any logged object under.
          */
         nestedKey?: string;
@@ -755,6 +763,8 @@ declare namespace pino {
         readonly formatOptsSym: unique symbol;
         readonly messageKeySym: unique symbol;
         readonly errorKeySym: unique symbol;
+        readonly responseKeySym: unique symbol;
+        readonly requestKeySym: unique symbol;
         readonly nestedKeySym: unique symbol;
         readonly wildcardFirstSym: unique symbol;
         readonly needsMetadataGsym: unique symbol;

--- a/pino.js
+++ b/pino.js
@@ -67,7 +67,7 @@ const defaultOptions = {
   serializers: Object.assign(Object.create(null), {
     err: defaultErrorSerializer,
     req: defaultRequestSerializer,
-    res: defaultResponseSerializer,
+    res: defaultResponseSerializer
   }),
   formatters: Object.assign(Object.create(null), {
     bindings (bindings) {

--- a/pino.js
+++ b/pino.js
@@ -20,6 +20,7 @@ const {
   noop
 } = require('./lib/tools')
 const { version } = require('./lib/meta')
+const { future: defaultFuture } = require('./lib/deprecations')
 const {
   chindingsSym,
   redactFmtSym,
@@ -45,7 +46,8 @@ const {
   hooksSym,
   nestedKeyStrSym,
   mixinMergeStrategySym,
-  msgPrefixSym
+  msgPrefixSym,
+  futureSym
 } = symbols
 const { epochTime, nullTime } = time
 const { pid } = process
@@ -87,7 +89,8 @@ const defaultOptions = {
   customLevels: null,
   useOnlyCustomLevels: false,
   depthLimit: 5,
-  edgeLimit: 100
+  edgeLimit: 100,
+  future: Object.assign(Object.create(null), defaultFuture)
 }
 
 const normalize = createArgsNormalizer(defaultOptions)
@@ -123,8 +126,11 @@ function pino (...args) {
     depthLimit,
     edgeLimit,
     onChild,
-    msgPrefix
+    msgPrefix,
+    future
   } = opts
+
+  const futureSafe = Object.assign(Object.create(null), defaultFuture, future)
 
   const stringifySafe = configure({
     maximumDepth: depthLimit,
@@ -209,7 +215,8 @@ function pino (...args) {
     [hooksSym]: hooks,
     silent: noop,
     onChild,
-    [msgPrefixSym]: msgPrefix
+    [msgPrefixSym]: msgPrefix,
+    [futureSym]: Object.freeze(futureSafe) // future is set immutable to each Pino top-instance, as it affects behavior of other settings
   })
 
   Object.setPrototypeOf(instance, proto())

--- a/pino.js
+++ b/pino.js
@@ -35,6 +35,8 @@ const {
   formatOptsSym,
   messageKeySym,
   errorKeySym,
+  requestKeySym,
+  responseKeySym,
   nestedKeySym,
   mixinSym,
   levelCompSym,
@@ -49,17 +51,23 @@ const { epochTime, nullTime } = time
 const { pid } = process
 const hostname = os.hostname()
 const defaultErrorSerializer = stdSerializers.err
+const defaultRequestSerializer = stdSerializers.req
+const defaultResponseSerializer = stdSerializers.res
 const defaultOptions = {
   level: 'info',
   levelComparison: SORTING_ORDER.ASC,
   levels: DEFAULT_LEVELS,
   messageKey: 'msg',
   errorKey: 'err',
+  requestKey: 'req',
+  responseKey: 'res',
   nestedKey: null,
   enabled: true,
   base: { pid, hostname },
   serializers: Object.assign(Object.create(null), {
-    err: defaultErrorSerializer
+    err: defaultErrorSerializer,
+    req: defaultRequestSerializer,
+    res: defaultResponseSerializer,
   }),
   formatters: Object.assign(Object.create(null), {
     bindings (bindings) {
@@ -99,6 +107,8 @@ function pino (...args) {
     timestamp,
     messageKey,
     errorKey,
+    requestKey,
+    responseKey,
     nestedKey,
     base,
     name,
@@ -186,6 +196,8 @@ function pino (...args) {
     [formatOptsSym]: formatOpts,
     [messageKeySym]: messageKey,
     [errorKeySym]: errorKey,
+    [requestKeySym]: requestKey,
+    [responseKeySym]: responseKey,
     [nestedKeySym]: nestedKey,
     // protect against injection
     [nestedKeyStrSym]: nestedKey ? `,${JSON.stringify(nestedKey)}:{` : '',

--- a/test/deprecations.test.js
+++ b/test/deprecations.test.js
@@ -1,0 +1,46 @@
+'use strict'
+const { test } = require('tap')
+const { future } = require('../lib/deprecations')
+const { futureSym } = require('../lib/symbols')
+const pino = require('../')
+
+test('instance future is copied from default future', async ({ same, not }) => {
+  const instance = pino()
+
+  not(instance[futureSym], future)
+  same(instance[futureSym], future)
+})
+
+test('instance future entries may be individually overridden by opts', async ({ match }) => {
+  const opts = { future: { skipUnconditionalStdSerializers: true } }
+  const instance = pino(opts)
+
+  match(instance[futureSym], { skipUnconditionalStdSerializers: true })
+})
+
+test('instance future entries are kept, when not individually overridden in opts', async ({ match }) => {
+  const instance = pino({ future: { foo: '-foo-' } })
+
+  match(instance[futureSym], future) // this is true because opts.future does not override any default property
+  match(instance[futureSym], { foo: '-foo-' })
+})
+
+test('instance future entries are immutable', async ({ throws }) => {
+  const instance = pino({ future: { foo: '-foo-' } })
+
+  throws(() => { instance[futureSym].foo = '-FOO-' }, TypeError)
+})
+
+test('child instance does not accept opts future', async ({ throws }) => {
+  const parent = pino({ future: { foo: '-foo-' } })
+
+  throws(() => parent.child({}, { future: { foo: '-FOO-' } }), RangeError)
+})
+
+test('child inherits future from parent and it is immutable', async ({ equal, throws }) => {
+  const parent = pino({ future: { foo: '-foo-' } })
+  const child = parent.child({})
+
+  equal(child[futureSym], parent[futureSym])
+  throws(() => { child[futureSym].foo = '-FOO-' }, TypeError)
+})

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -83,41 +83,79 @@ test('http request support via serializer', async ({ ok, same, error, teardown }
   server.close()
 })
 
-test('http request support via serializer (avoids stdSerializers)', async ({ error, equal, match }) => {
-  let originalReq
-  const instance = pino({
-    requestKey: 'myRequest',
-    serializers: {
-      req: (req) => {
-        equal(req, originalReq)
-        return req.arbitraryProperty
+test('http request support via serializer (avoids stdSerializers)', async ({ test }) => {
+  test('current behavior in major-version 9', async ({ equal, not, error }) => {
+    let originalReq
+    const instance = pino({
+      serializers: {
+        req: (req) => {
+          // original request object is already replaced by pino.stdSerializers.req
+          not(req, originalReq)
+          equal(req.arbitraryProperty, undefined)
+          return req
+        }
       }
-    }
-  }, sink((chunk, _enc) => {
-    match(chunk, {
-      pid,
-      hostname,
-      level: 30,
-      msg: 'my request',
-      myRequest: originalReq.arbitraryProperty
+    }, sink())
+
+    const server = http.createServer(function (req, res) {
+      originalReq = req
+      req.arbitraryProperty = Math.random()
+
+      instance.info(req, 'my response')
+      res.end('hello')
     })
-  }))
 
-  const server = http.createServer(function (req, res) {
-    originalReq = req
-    req.arbitraryProperty = Math.random()
+    server.unref()
+    server.listen()
+    const err = await once(server, 'listening')
+    error(err)
 
-    instance.info(req, 'my request')
-    res.end('hello')
+    const res = await once(http.get('http://localhost:' + server.address().port), 'response')
+    res.resume()
+    server.close()
   })
-  server.unref()
-  server.listen()
-  const err = await once(server, 'listening')
-  error(err)
 
-  const res = await once(http.get('http://localhost:' + server.address().port), 'response')
-  res.resume()
-  server.close()
+  test('future behavior', async ({ error, equal, match }) => {
+    const resultOfSerialization = Math.random()
+    let originalReq
+    const instance = pino({
+      requestKey: 'myRequest',
+      serializers: {
+        req: (req) => {
+          equal(req, originalReq)
+          equal(req.arbitraryProperty, originalReq.arbitraryProperty)
+          return resultOfSerialization
+        }
+      },
+      future: {
+        skipUnconditionalStdSerializers: true
+      }
+    }, sink((chunk, _enc) => {
+      match(chunk, {
+        pid,
+        hostname,
+        level: 30,
+        msg: 'my request',
+        myRequest: resultOfSerialization
+      })
+    }))
+
+    const server = http.createServer(function (req, res) {
+      originalReq = req
+      req.arbitraryProperty = Math.random()
+
+      instance.info(req, 'my request')
+      res.end('hello')
+    })
+    server.unref()
+    server.listen()
+    const err = await once(server, 'listening')
+    error(err)
+
+    const res = await once(http.get('http://localhost:' + server.address().port), 'response')
+    res.resume()
+    server.close()
+  })
 })
 
 // skipped because request connection is deprecated since v13, and request socket is always available
@@ -237,42 +275,79 @@ test('http response support via a serializer', async ({ ok, same, error, teardow
   server.close()
 })
 
-test('http response support via serializer (avoids stdSerializers)', async ({ match, equal, error }) => {
-  let originalRes
-  const instance = pino({
-    responseKey: 'myResponse',
-    serializers: {
-      res: (res) => {
-        equal(res, originalRes)
-        return res.arbitraryProperty
+test('http response support via serializer (avoids stdSerializers)', async ({ test }) => {
+  test('current behavior in major-version 9', async ({ equal, not, error }) => {
+    let originalRes
+    const instance = pino({
+      serializers: {
+        res: (res) => {
+          // original response object is already replaced by pino.stdSerializers.res
+          not(res, originalRes)
+          equal(res.arbitraryProperty, undefined)
+          return res
+        }
       }
-    }
-  }, sink((chunk, _enc) => {
-    match(chunk, {
-      pid,
-      hostname,
-      level: 30,
-      msg: 'my response',
-      myResponse: originalRes.arbitraryProperty
+    }, sink())
+
+    const server = http.createServer(function (_req, res) {
+      originalRes = res
+      res.arbitraryProperty = Math.random()
+
+      instance.info(res, 'my response')
+      res.end('hello')
     })
-  }))
 
-  const server = http.createServer(function (_req, res) {
-    originalRes = res
-    res.arbitraryProperty = Math.random()
+    server.unref()
+    server.listen()
+    const err = await once(server, 'listening')
+    error(err)
 
-    instance.info(res, 'my response')
-    res.end('hello')
+    const res = await once(http.get('http://localhost:' + server.address().port), 'response')
+    res.resume()
+    server.close()
   })
+  test('future behavior', async ({ match, equal, error }) => {
+    const resultOfSerialization = Math.random()
+    let originalRes
+    const instance = pino({
+      responseKey: 'myResponseKey',
+      serializers: {
+        res: (res) => {
+          equal(res, originalRes)
+          equal(res.arbitraryProperty, originalRes.arbitraryProperty)
+          return resultOfSerialization
+        }
+      },
+      future: {
+        skipUnconditionalStdSerializers: true
+      }
+    }, sink((chunk, _enc) => {
+      match(chunk, {
+        pid,
+        hostname,
+        level: 30,
+        msg: 'my response',
+        myResponseKey: resultOfSerialization
+      })
+    }))
 
-  server.unref()
-  server.listen()
-  const err = await once(server, 'listening')
-  error(err)
+    const server = http.createServer(function (_req, res) {
+      originalRes = res
+      res.arbitraryProperty = Math.random()
 
-  const res = await once(http.get('http://localhost:' + server.address().port), 'response')
-  res.resume()
-  server.close()
+      instance.info(res, 'my response')
+      res.end('hello')
+    })
+
+    server.unref()
+    server.listen()
+    const err = await once(server, 'listening')
+    error(err)
+
+    const res = await once(http.get('http://localhost:' + server.address().port), 'response')
+    res.resume()
+    server.close()
+  })
 })
 
 test('http request support via serializer in a child', async ({ ok, same, error, teardown }) => {

--- a/test/http.test.js
+++ b/test/http.test.js
@@ -47,6 +47,7 @@ test('http request support', async ({ ok, same, error, teardown }) => {
 test('http request support via serializer', async ({ error, match }) => {
   let originalReq
   const instance = pino({
+    requestKey: 'myRequest',
     serializers: {
       req: (req) => req.arbitraryProperty,
     }
@@ -56,7 +57,7 @@ test('http request support via serializer', async ({ error, match }) => {
       hostname,
       level: 30,
       msg: 'my request',
-      req: originalReq.arbitraryProperty,
+      myRequest: originalReq.arbitraryProperty,
     })
   }))
 
@@ -70,7 +71,6 @@ test('http request support via serializer', async ({ error, match }) => {
   server.unref()
   server.listen()
   const err = await once(server, 'listening')
-  error(err)
 
   const res = await once(http.get('http://localhost:' + server.address().port), 'response')
   res.resume()
@@ -157,16 +157,17 @@ test('http response support', async ({ ok, same, error, teardown }) => {
 test('http response support via a serializer', async ({ match, error }) => {
   let originalRes
   const instance = pino({
+    responseKey: 'myResponse',
     serializers: {
       res: (res) => res.arbitraryProperty,
     }
-  }, sink((chunk, enc) => {
+  }, sink((chunk, _enc) => {
     match(chunk, {
       pid,
       hostname,
       level: 30,
       msg: 'my response',
-      res: originalRes.arbitraryProperty,
+      myResponse: originalRes.arbitraryProperty,
     })
   }))
 
@@ -196,7 +197,7 @@ test('http request support via serializer in a child', async ({ ok, same, error,
     serializers: {
       req: pino.stdSerializers.req
     }
-  }, sink((chunk, enc) => {
+  }, sink((chunk, _enc) => {
     ok(new Date(chunk.time) <= new Date(), 'time is greater than Date.now()')
     delete chunk.time
     same(chunk, {
@@ -224,7 +225,6 @@ test('http request support via serializer in a child', async ({ ok, same, error,
   server.unref()
   server.listen()
   const err = await once(server, 'listening')
-  error(err)
 
   const res = await once(http.get('http://localhost:' + server.address().port), 'response')
   res.resume()

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -118,7 +118,9 @@ test('child does not overwrite parent serializers', async ({ equal }) => {
 test('Symbol.for(\'pino.serializers\')', async ({ equal, same, not }) => {
   const stream = sink()
   const expected = Object.assign({
-    err: stdSerializers.err
+    err: stdSerializers.err,
+    req: stdSerializers.req,
+    res: stdSerializers.res
   }, parentSerializers)
   const parent = pino({ serializers: parentSerializers }, stream)
   const child = parent.child({ a: 'property' })
@@ -158,7 +160,9 @@ test('children inherit parent Symbol serializers', async ({ equal, same, not }) 
     [Symbol.for('b')]: b
   }
   const expected = Object.assign({
-    err: stdSerializers.err
+    err: stdSerializers.err,
+    req: stdSerializers.req,
+    res: stdSerializers.res
   }, symbolSerializers)
   const parent = pino({ serializers: symbolSerializers }, stream)
 


### PR DESCRIPTION
When serializers are defined for HTTP Request or HTTP Response, do not run the correspondent `stdSerializers` before calling the provided serializer functions.

ISSUE https://github.com/pinojs/pino/issues/1991